### PR TITLE
feat: Add repository link to logo and MIT license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Enrique Revuelta
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,8 @@ description = "Conversational AI scouting platform – FastAPI backend, Django U
 authors = [
   { name = "Enrique Revuelta", email = "enrique.revuelta@bain.com" }
 ]
+license = { text = "MIT" }
+readme = "README.md"
 requires-python = ">=3.11"
 
 dependencies = [

--- a/templates/dashboard/home.html
+++ b/templates/dashboard/home.html
@@ -7,10 +7,16 @@
   <!-- Logo of the application -->
   <section class="text-center py-3" role="banner">
     <div class="logo-container">
-      <img src="{% static 'img/app_logo_6.png' %}"    
-           alt="Smart Scout - Application of football analysis with artificial intelligence"
-           class="img-fluid app-logo glass-logo"
-           role="img">
+      <a href="https://github.com/KikeRev/smart_scout_app" 
+         target="_blank" 
+         rel="noopener noreferrer"
+         title="View source code on GitHub"
+         aria-label="View Smart Scout App source code on GitHub">
+        <img src="{% static 'img/app_logo_6.png' %}"    
+             alt="Smart Scout - Application of football analysis with artificial intelligence"
+             class="img-fluid app-logo glass-logo"
+             role="img">
+      </a>
     </div>
   </section>
   


### PR DESCRIPTION
- Make logo clickable linking to GitHub repository
- Add proper accessibility attributes (aria-label, title)
- Open link in new tab with security attributes (rel=noopener noreferrer)
- Add MIT license file for open source compliance
- Update pyproject.toml with license information
- Improve project transparency and code accessibility